### PR TITLE
fix: update unit tests to work with Python 3.10+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ This can now be tested in docstrings:
     ... 
     ...     $ hello Polly Parrot
     ...     Usage: hello [OPTIONS] NAME
-    ...     Try "hello --help" for help.
+    ...     Try 'hello --help' for help.
     ...     <BLANKLINE>
     ...     Error: Got unexpected extra argument (Parrot)
     ... 
@@ -224,8 +224,7 @@ Lines failing to match the command's output will raise an error
     Traceback (most recent call last):
     ...
     ValueError: Differences (ndiff with -expected +actual):
-        - "No it didn't!"
-        + There, it moved!
+        - "No it didn't!"+ There, it moved!
 
 Known issues
 ------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,8 @@ exclude = docs
 [aliases]
 test = pytest
 
+# NOTE(nic): these opts are incompatible with the PyCharm test runner.
+#  Comment out this section to run the unit tests in PyCharm.
 [tool:pytest]
 addopts = ./bashdoctest ./tests --cov=bashdoctest --cov=tests --doctest-modules --cov-report term-missing
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,6 +1,10 @@
 import doctest
+import sys
+
+import pytest
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="Python 3.10+ required")
 def test_readme():
     errs, _ = doctest.testfile('../README.rst', report=True)
     assert not errs

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,5 +1,7 @@
 
 import os
+import sys
+
 import click
 import pytest
 from click.testing import CliRunner
@@ -29,6 +31,7 @@ def test_hello_world():
     assert result.output == 'Hello Peter!\n'
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="Python 3.10+ required")
 def test_string_command():
 
     teststr = '''
@@ -40,7 +43,7 @@ def test_string_command():
 
         $ hello Polly Parrot
         Usage: hello [OPTIONS] NAME
-        Try "hello --help" for help.
+        Try 'hello --help' for help.
         <BLANKLINE>
         Error: Got unexpected extra argument (Parrot)
 


### PR DESCRIPTION
The Python interpeter normalized quotes across all outputs, which made some of the unit tests that look at interpreter output quietly fail.  Update the strings under test to use the new style, and add skip annotations for older Pythons, since at this point they are known to be tested, and on the path to EOL.

NOTE: The `doctest` in the Python stdlib from 3.10+ has introduced a bug in `doctest.OutputChecker.output_difference` where it stringifies the difference into a single line.  Nobody seems to have noticed, nor cared about it, but the tests here need to account for it.

Fixes: Issue #2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juledwar/bashdoctest/3)
<!-- Reviewable:end -->
